### PR TITLE
Update docs to correct the meter metric name in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ From: <a href="http://metrics.codahale.com/getting-started/#meters">Meters</a>:
     class Rdio
       extend Simple::Metrics::Meter
 
-      define_meter :bump
+      define_meter :bump_meter
 
       def bump_dat
         bump_meter.mark

--- a/doc/file.README.html
+++ b/doc/file.README.html
@@ -131,7 +131,7 @@
 <pre class="code ruby"><code><span class='rubyid_class class kw'>class</span> <span class='rubyid_Rdio constant id'>Rdio</span>
   <span class='rubyid_extend identifier id'>extend</span> <span class='rubyid_Simple constant id'>Simple</span><span class='colon2 op'>::</span><span class='rubyid_Metrics constant id'>Metrics</span><span class='colon2 op'>::</span><span class='rubyid_Meter constant id'>Meter</span>
 
-  <span class='rubyid_define_meter identifier id'>define_meter</span> <span class='symbol val'>:bump</span>
+  <span class='rubyid_define_meter identifier id'>define_meter</span> <span class='symbol val'>:bump_meter</span>
 
   <span class='rubyid_def def kw'>def</span> <span class='rubyid_bump_dat identifier id'>bump_dat</span>
     <span class='rubyid_bump_meter identifier id'>bump_meter</span><span class='dot token'>.</span><span class='rubyid_mark identifier id'>mark</span>

--- a/doc/index.html
+++ b/doc/index.html
@@ -131,7 +131,7 @@
 <pre class="code ruby"><code><span class='rubyid_class class kw'>class</span> <span class='rubyid_Rdio constant id'>Rdio</span>
   <span class='rubyid_extend identifier id'>extend</span> <span class='rubyid_Simple constant id'>Simple</span><span class='colon2 op'>::</span><span class='rubyid_Metrics constant id'>Metrics</span><span class='colon2 op'>::</span><span class='rubyid_Meter constant id'>Meter</span>
 
-  <span class='rubyid_define_meter identifier id'>define_meter</span> <span class='symbol val'>:bump</span>
+  <span class='rubyid_define_meter identifier id'>define_meter</span> <span class='symbol val'>:bump_meter</span>
 
   <span class='rubyid_def def kw'>def</span> <span class='rubyid_bump_dat identifier id'>bump_dat</span>
     <span class='rubyid_bump_meter identifier id'>bump_meter</span><span class='dot token'>.</span><span class='rubyid_mark identifier id'>mark</span>


### PR DESCRIPTION
The meter examples defined a metric called `:bump`, however the
`bump_dat` method tries to use a metric named `bump_meter`. This raises
since this is the incorrect name of the metric. Updated the `:bump`
metric to be `:bump_meter`.
