### PR TITLE
Update define_meter to take optional TimeUnit argument

### DIFF
--- a/lib/simple/metrics/meter.rb
+++ b/lib/simple/metrics/meter.rb
@@ -8,11 +8,12 @@ module Simple
       # @param [String] name The name of the meter
       # @param [String] klass_name The name of the class, usually the application. Defaults to
       # `self.class.name`
-      def define_meter(name, klass_name = self.class.name)
+      # @param [TimeUnit] time_unit The rate at which to measure marked data. Defaults to
+      # TimeUnit::SECONDS
+      def define_meter(name, klass_name = self.class.name, time_unit = Simple::Metrics::DEFAULT_RATE_UNIT)
         type = "meter"
         metric_name = new_metric_name(klass_name, name, type)
-        meter = Java::ComYammerMetrics::Metrics.new_meter(metric_name, name.to_s,
-                                                            Simple::Metrics::DEFAULT_RATE_UNIT)
+        meter = Java::ComYammerMetrics::Metrics.new_meter(metric_name, name.to_s, time_unit)
         define_method("#{name}") do
           meter
         end


### PR DESCRIPTION
Expose the ability for consumers to change the rate at which meters
are measured by metrics. This change maintain the original default of
TimeUnit::SECONDS and is the default value on the method signature.
